### PR TITLE
ACCEPTED: Disable Project File output spam as default

### DIFF
--- a/Source/Modio/Modio.Build.cs
+++ b/Source/Modio/Modio.Build.cs
@@ -25,6 +25,8 @@ using System.Linq;
 
 public class Modio : ModuleRules
 {
+    private const bool TraceLogEnabled = false;
+
     private bool PlatformMatches(UnrealTargetPlatform PlatformToCheck, string PlatformIdentifier)
     {
         UnrealTargetPlatform Platform;
@@ -123,7 +125,10 @@ public class Modio : ModuleRules
             /*if (PlatformName != PlatformString)
             {
                 // Platforms that do not match the PlatformName are skipped
-                // Log.TraceInformation("Platform name " + PlatformName + " does not match String " + PlatformString);
+                // if (TraceLogEnabled)
+                // {
+                //     Log.TraceInformation("Platform name " + PlatformName + " does not match String " + PlatformString);
+                // }
                 continue;
             }*/
 
@@ -140,7 +145,11 @@ public class Modio : ModuleRules
                     {
                         if (PlatformMatches(Target.Platform, Platform.Key))
                         {
-                            Log.TraceInformation("Merging in platform configuration " + Platform.Key);
+                            if (TraceLogEnabled)
+                            {
+                                Log.TraceInformation("Merging in platform configuration " + Platform.Key);
+                            }
+
                             //This is the first matching platform we've found, so create our config
                             if (MergedConfig == null)
                             {
@@ -315,7 +324,11 @@ public class Modio : ModuleRules
         {
             string RootPlatformName = PlatformPath.Replace('/', Path.DirectorySeparatorChar).Split(Path.DirectorySeparatorChar).First();
             ConditionalAddModuleDirectory(new DirectoryReference(Path.Combine(GeneratedSourcePath, RootPlatformName)));
-            Log.TraceInformation("Adding native platform source directory " + Path.Combine(GeneratedSourcePath, RootPlatformName));
+
+            if (TraceLogEnabled)
+            {
+                Log.TraceInformation("Adding native platform source directory " + Path.Combine(GeneratedSourcePath, RootPlatformName));
+            }
         }
         // Add any platform-specific additional modules as private dependencies
         PrivateDependencyModuleNames.AddRange(Config.ModuleDependencies.ToArray());
@@ -401,7 +414,10 @@ public class Modio : ModuleRules
             throw new BuildException("Could not locate native platform configuration file. If you are using a confidential platform, please ensure you have placed the platform code into the correct directory.");
         }
 
-        DumpNativePlatformConfig(PlatformConfig);
+        if (TraceLogEnabled)
+        {
+            DumpNativePlatformConfig(PlatformConfig);
+        }
 
         // When using the native SDK as a submodule, transform the SDK source into paths and files that UBT understands
         // These are all no-ops in marketplace builds or anywhere with 'baked' source files

--- a/Source/Modio/Modio.Build.cs
+++ b/Source/Modio/Modio.Build.cs
@@ -10,6 +10,8 @@
 
 // Copyright 1998-2019 Epic Games, Inc. All Rights Reserved.
 
+//#define ENABLE_TRACE_LOG
+
 using System;
 using System.IO;
 using System.Collections.Generic;
@@ -25,8 +27,6 @@ using System.Linq;
 
 public class Modio : ModuleRules
 {
-    private const bool TraceLogEnabled = false;
-
     private bool PlatformMatches(UnrealTargetPlatform PlatformToCheck, string PlatformIdentifier)
     {
         UnrealTargetPlatform Platform;
@@ -125,10 +125,9 @@ public class Modio : ModuleRules
             /*if (PlatformName != PlatformString)
             {
                 // Platforms that do not match the PlatformName are skipped
-                // if (TraceLogEnabled)
-                // {
+                // #if ENABLE_TRACE_LOG
                 //     Log.TraceInformation("Platform name " + PlatformName + " does not match String " + PlatformString);
-                // }
+                // #endif
                 continue;
             }*/
 
@@ -145,10 +144,9 @@ public class Modio : ModuleRules
                     {
                         if (PlatformMatches(Target.Platform, Platform.Key))
                         {
-                            if (TraceLogEnabled)
-                            {
-                                Log.TraceInformation("Merging in platform configuration " + Platform.Key);
-                            }
+#if ENABLE_TRACE_LOG
+                            Log.TraceInformation("Merging in platform configuration " + Platform.Key);
+#endif
 
                             //This is the first matching platform we've found, so create our config
                             if (MergedConfig == null)
@@ -325,10 +323,9 @@ public class Modio : ModuleRules
             string RootPlatformName = PlatformPath.Replace('/', Path.DirectorySeparatorChar).Split(Path.DirectorySeparatorChar).First();
             ConditionalAddModuleDirectory(new DirectoryReference(Path.Combine(GeneratedSourcePath, RootPlatformName)));
 
-            if (TraceLogEnabled)
-            {
-                Log.TraceInformation("Adding native platform source directory " + Path.Combine(GeneratedSourcePath, RootPlatformName));
-            }
+#if ENABLE_TRACE_LOG
+            Log.TraceInformation("Adding native platform source directory " + Path.Combine(GeneratedSourcePath, RootPlatformName));
+#endif
         }
         // Add any platform-specific additional modules as private dependencies
         PrivateDependencyModuleNames.AddRange(Config.ModuleDependencies.ToArray());
@@ -414,10 +411,9 @@ public class Modio : ModuleRules
             throw new BuildException("Could not locate native platform configuration file. If you are using a confidential platform, please ensure you have placed the platform code into the correct directory.");
         }
 
-        if (TraceLogEnabled)
-        {
-            DumpNativePlatformConfig(PlatformConfig);
-        }
+#if ENABLE_TRACE_LOG
+        DumpNativePlatformConfig(PlatformConfig);
+#endif
 
         // When using the native SDK as a submodule, transform the SDK source into paths and files that UBT understands
         // These are all no-ops in marketplace builds or anywhere with 'baked' source files


### PR DESCRIPTION
Modio was the only plugin that wrote debug information into the result of Project File Generation, making it overly verbose.

This change disables this spam as default (but keeps the logging feature for debugging purposes).